### PR TITLE
feat: add Renovate automation with daily dependency scanning

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,59 @@
+name: Renovate
+
+on:
+  # Run daily at 6 AM UTC
+  schedule:
+    - cron: '0 6 * * *'
+  # Allow manual triggering
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Renovate log level'
+        required: false
+        default: 'info'
+        type: choice
+        options:
+          - info
+          - debug
+          - trace
+
+# Ensure only one Renovate workflow runs at a time
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  renovate:
+    name: Renovate Dependencies
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22.x'
+          cache: 'pnpm'
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@v44.0.4
+        with:
+          configurationFile: renovate.json
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          # Set log level from manual input or default to info
+          LOG_LEVEL: ${{ github.event.inputs.logLevel || 'info' }}
+          # Enable renovate to create PRs and issues
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          # Use GitHub App token if available, otherwise use PAT
+          RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,54 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits",
+    ":automergeDigest",
+    ":automergeBranch"
+  ],
+  "timezone": "UTC",
+  "schedule": ["before 8am on monday"],
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "description": "Group Angular packages together",
+      "groupName": "Angular",
+      "matchPackagePatterns": ["^@angular/"]
+    },
+    {
+      "description": "Group NestJS packages together", 
+      "groupName": "NestJS",
+      "matchPackagePatterns": ["^@nestjs/"]
+    },
+    {
+      "description": "Group Nx packages together",
+      "groupName": "Nx",
+      "matchPackagePatterns": ["^@nx/", "^nx$"]
+    },
+    {
+      "description": "Group TypeScript ESLint packages together",
+      "groupName": "TypeScript ESLint",
+      "matchPackagePatterns": ["^@typescript-eslint/"]
+    },
+    {
+      "description": "Auto-merge patch and minor updates for development dependencies",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true
+    },
+    {
+      "description": "Auto-merge patch updates for production dependencies",
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["patch"],
+      "automerge": true
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "osvVulnerabilityAlerts": true,
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "stabilityDays": 3
 }


### PR DESCRIPTION
- Add GitHub Actions workflow for daily Renovate runs at 6 AM UTC
- Enable manual workflow dispatch with configurable log levels
- Enhance renovate.json with intelligent package grouping and auto-merge policies
- Add comprehensive setup documentation in RENOVATE_SETUP.md

Features:
- Smart grouping for Angular, NestJS, Nx, and TypeScript ESLint packages
- Auto-merge for safe patch updates (prod) and patch+minor updates (dev)
- Vulnerability alerts and dependency dashboard
- Rate limiting: 5 concurrent PRs, 2 PRs per hour, 3-day stability period
- Semantic commits for clear PR history

Setup required: Add RENOVATE_TOKEN secret with GitHub PAT

### Before submitting the PR, please make sure you do the following:

- [ ] Read the [Contributing Guidelines](https://github.com/Amadeus-xDLC/renovate-playground/blob/main/CONTRIBUTING.md)
- [ ] Reference your PR to an issue that was discussed ahead of time
- [ ] The PR should contain a clear description of the problem it solves
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests and linting

- [ ] Run the unit tests with `pnpm test`
- [ ] Run the linting with `pnpm lint`
- [ ] Run the build with `pnpm build`

Thank you for contributing to Renovate Playground!
